### PR TITLE
Add BACKDROP_SETTINGS to $_SERVER if its been set in the environment

### DIFF
--- a/BackdropBoot.php
+++ b/BackdropBoot.php
@@ -426,6 +426,12 @@ class BackdropBoot extends BaseBoot {
     $_SERVER['SERVER_SOFTWARE'] = NULL;
     $_SERVER['HTTP_USER_AGENT'] = NULL;
     $_SERVER['SCRIPT_FILENAME'] = DRUPAL_ROOT . '/index.php';
+    
+    // Allows the user to drop in db connection info by setting BACKDROP_SETTINGS in the environment
+    // This is helpful when backdrops database connection is not specified in settings.php such as on Pantheon or Kalabox
+    if (getenv('BACKDROP_SETTINGS') !== false) {
+      $_SERVER['BACKDROP_SETTINGS'] = getenv('BACKDROP_SETTINGS');
+    }
   }
 
   /**


### PR DESCRIPTION
Small PR to make sure `BACKDROP_SETTINGS` gets added to the `$_SERVER` global if its been set in the environment. 

This is needed to get drush to bootstrap if you are running Backdrop o Kalabox using 
https://github.com/backdrop-ops/backdrop-docker and https://github.com/RobLoach/drush-docker/tree/master/backdrop
