### PR TITLE
7/add enable module support

### DIFF
--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -56,6 +56,9 @@ function backdrop_drush_command_alter(&$command) {
     case 'core-status':
       $backdrop_command = 'backdrop-core-status';
       break;
+    case 'pm-update':
+      $backdrop_command = 'backdrop-pm-update';
+      break;
   }
 
   // Commands that work with Backdrop with no adjustments.

--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -59,6 +59,12 @@ function backdrop_drush_command_alter(&$command) {
     case 'pm-update':
       $backdrop_command = 'backdrop-pm-update';
       break;
+    case 'pm-enable':
+      $backdrop_command = 'backdrop-pm-enable';
+      break;
+    case 'pm-disable':
+      $backdrop_command = 'backdrop-pm-disable';
+      break;
   }
 
   // Commands that work with Backdrop with no adjustments.

--- a/commands/backdrop_pm.drush.inc
+++ b/commands/backdrop_pm.drush.inc
@@ -8,7 +8,6 @@
  */
 function backdrop_pm_drush_command() {
   $items = array();
-
   $items['backdrop-pm-download'] = array(
     'description' => 'Download Backdrop CMS contrib modules.',
     'callback' => 'backdrop_command_pm_download',
@@ -22,7 +21,20 @@ function backdrop_pm_drush_command() {
     'required-arguments' => TRUE,
     'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_SITE,
   );
-
+  $items['backdrop-pm-update'] = array(
+    'description' => 'Update Backdrop core or contrib modules.',
+    'callback' => 'backdrop_command_pm_update',
+    'arguments' => array(
+      'module-name' => array('The name of the module(s) you would like to update.'),
+    ),
+    // TODO: show available updates and allow for selection of which to apply.
+    //'options' => array(
+    //  'show' => "Select from available updates:"
+    //),
+    'aliases' => array('up',),
+    'required-arguments' => TRUE,
+    'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_SITE,
+  );
   return $items;
 }
 
@@ -209,5 +221,79 @@ function backdrop_pm_dl_outcome($module_install_location, $project) {
   }
   else {
     print "\n\t\033[31m Error: \033[0m Project $project could not be found.\n\n";
+  }
+}
+
+/**
+ * Command callback for pm-update.
+ * Currently supports druhs up backdrop only.
+ * TODO: support updating modules.
+ */
+function backdrop_command_pm_update() {
+  $projects = func_get_args();
+  $projects[0] = strtolower($projects[0]);
+  if ($projects[0] === 'backdrop') {
+    // get current Backdrop version info.
+    $current_version = BACKDROP_VERSION;
+    $parse_version = explode('.', $current_version);
+    $current_version_major = $parse_version[0];
+    $current_version_minor = $parse_version[1];
+    $current_version_patch = $parse_version[2];
+    // Get proposed Backdrop version info.
+    $xml = backdrop_pm_get_tags("https://updates.backdropcms.org/release-history/backdrop/1.x");
+    $download_link = $xml->releases->release->download_link;
+    $proposed_version = $xml->releases->release->version;
+    $proposed_version_major = $xml->releases->release->version_major;
+    $proposed_version_minor = $xml->releases->release->version_minor;
+    $proposed_version_patch = $xml->releases->release->version_patch;
+    if ($current_version == $proposed_version) {
+      drush_print_r("\n\t\tBackdrop is up to date :).\n");
+    }
+    elseif ($current_version_major < $proposed_version_major) {
+      drush_print_r("\n\t\tYou can not use drush up to move between Major Versions of Backdrop.");
+    }
+    elseif (
+      (
+        $current_version_major == $proposed_version_major &&
+        $current_version_minor == $proposed_version_minor &&
+        $current_version_patch < $proposed_version_patch
+      ) ||
+      (
+        $current_version_major == $proposed_version_major &&
+        $current_version_minor < $proposed_version_minor
+      )
+    ) {
+      drush_print_r("\n\t\tCurrent Backdrop Version: $current_version
+      \t\tProposed Backdrop Version: $proposed_version\n");
+      drush_print_r("\tCode updates will be made to Backdrop core.\n");
+      drush_print_r("\t\e[33mWARNING\033[0m:  Updating core will discard any
+      modifications made to Backdrop core files.  If you have made any
+      modifications to these files, please back them up before updating so that
+      you can re-create your modifications in the updated version of the file.\n\n");
+      drush_print_r("\tNote: Updating core can potentially break your site.
+      It is NOT recommended to update production sites without prior testing.\n\n");
+      $answer = drush_prompt("Do you wish to continue? (y or n)");
+      $answer = strtolower($answer);
+      if ($answer == 'y' || $answer == 'yes') {
+        drush_print_r("\t Backing up current core folder to ~/.drush/core-$current_version");
+        $backdrop_root = BACKDROP_ROOT;
+        exec("mv $backdrop_root/core ~/.drush/core-$current_version");
+        exec("mkdir -p $backdrop_root/drush-tmp");
+        exec("wget --quiet -P $backdrop_root/drush-tmp $download_link");
+        exec("unzip $backdrop_root/drush-tmp/backdrop.zip -d $backdrop_root/drush-tmp");
+        exec("mv $backdrop_root/drush-tmp/backdrop/core $backdrop_root/core");
+        exec("rm -r $backdrop_root/drush-tmp");
+        exec("drush updb -y");
+        drush_print_r("\n\tYou can retrieve your old core files, should you need
+        to from: ~/.drush/core-$current_version");
+        drush_print_r("\t\e[32mSuccess\033[0m: Backdrop updated to $proposed_version.");
+      }
+      else {
+        drush_print_r("\tBackdrop core update cancelled.");
+      }
+    }
+    else {
+      drush_print_r("\n\tNo Backdrop core updates available. Your Backdrop is up to date!\n");
+    }
   }
 }

--- a/commands/backdrop_pm.drush.inc
+++ b/commands/backdrop_pm.drush.inc
@@ -25,7 +25,7 @@ function backdrop_pm_drush_command() {
     'description' => 'Update Backdrop core or contrib modules.',
     'callback' => 'backdrop_command_pm_update',
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to update.'),
+      'module-name' => array('The name of the module you would like to update.'),
     ),
     // TODO: show available updates and allow for selection of which to apply.
     //'options' => array(
@@ -34,6 +34,26 @@ function backdrop_pm_drush_command() {
     'aliases' => array('up',),
     'required-arguments' => TRUE,
     'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_SITE,
+  );
+  $items['backdrop-pm-enable'] = array(
+    'description' => 'Enable backdrop modules.',
+    'callback' => 'backdrop_command_pm_enable',
+    'arguments' => array(
+      'module-name' => array('The name of the module(s) you would like to enable.'),
+    ),
+    'aliases' => array('en',),
+    'required-arguments' => TRUE,
+    'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_FULL,
+  );
+  $items['backdrop-pm-disable'] = array(
+    'description' => 'Disable backdrop modules.',
+    'callback' => 'backdrop_command_pm_disable',
+    'arguments' => array(
+      'module-name' => array('The name of the module(s) you would like to disable.'),
+    ),
+    'aliases' => array('dis',),
+    'required-arguments' => TRUE,
+    'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_FULL,
   );
   return $items;
 }
@@ -226,8 +246,6 @@ function backdrop_pm_dl_outcome($module_install_location, $project) {
 
 /**
  * Command callback for pm-update.
- * Currently supports druhs up backdrop only.
- * TODO: support updating modules.
  */
 function backdrop_command_pm_update() {
   $projects = func_get_args();
@@ -388,5 +406,30 @@ function backdrop_command_pm_update() {
     drush_print_r("\n\tYou must specify a project to update. For example:\n");
     drush_print_r("\t\tdrush up project_name");
     drush_print_r("\n\tWhere project_name is the machine name of the project like webform or devel etc.\n");
+  }
+}
+
+/**
+ * Command callback for pm-enable.
+ */
+function backdrop_command_pm_enable() {
+  $projects = func_get_args();
+  drush_print_r($projects);
+  if (!empty($projects)) {
+    include_once BACKDROP_ROOT . '/core/includes/module.inc';
+    module_enable($projects);
+    drush_print_r("\t\033[32mSuccess\033[0");
+  }
+}
+
+/**
+ * Command callback for pm-disable.
+ */
+function backdrop_command_pm_disable() {
+  $projects = func_get_args();
+  if (!empty($projects)) {
+    include_once BACKDROP_ROOT . '/core/includes/module.inc';
+    module_disable($projects);
+    drush_print_r("\t\033[32mSuccess\033[0");
   }
 }

--- a/commands/backdrop_pm.drush.inc
+++ b/commands/backdrop_pm.drush.inc
@@ -232,6 +232,7 @@ function backdrop_pm_dl_outcome($module_install_location, $project) {
 function backdrop_command_pm_update() {
   $projects = func_get_args();
   $projects[0] = strtolower($projects[0]);
+  $backdrop_root = BACKDROP_ROOT;
   if ($projects[0] === 'backdrop') {
     // get current Backdrop version info.
     $current_version = BACKDROP_VERSION;
@@ -246,6 +247,7 @@ function backdrop_command_pm_update() {
     $proposed_version_major = $xml->releases->release->version_major;
     $proposed_version_minor = $xml->releases->release->version_minor;
     $proposed_version_patch = $xml->releases->release->version_patch;
+
     if ($current_version == $proposed_version) {
       drush_print_r("\n\t\tBackdrop is up to date :).\n");
     }
@@ -276,7 +278,6 @@ function backdrop_command_pm_update() {
       $answer = strtolower($answer);
       if ($answer == 'y' || $answer == 'yes') {
         drush_print_r("\t Backing up current core folder to ~/.drush/core-$current_version");
-        $backdrop_root = BACKDROP_ROOT;
         exec("mv $backdrop_root/core ~/.drush/core-$current_version");
         exec("mkdir -p $backdrop_root/drush-tmp");
         exec("wget --quiet -P $backdrop_root/drush-tmp $download_link");
@@ -295,5 +296,97 @@ function backdrop_command_pm_update() {
     else {
       drush_print_r("\n\tNo Backdrop core updates available. Your Backdrop is up to date!\n");
     }
+  } // end of drush up backdrop.
+  elseif (!empty($projects[0])) {
+    if (file_exists("$backdrop_root/modules/contrib")) {
+      $module_path = "$backdrop_root/modules/contrib";
+    }
+    else {
+      $module_path = "$backdrop_root/modules";
+    }
+    $ls = scandir($module_path);
+    $projects[0] = strtolower($projects[0]);
+    if (in_array($projects[0], $ls)) {
+      $info = file("$module_path/$projects[0]/$projects[0].info", FILE_IGNORE_NEW_LINES);
+      foreach($info as $i) {
+        if (strpos($i, 'version =') !== FALSE) {
+          $module_version_raw = $i;
+        }
+      }
+      $module_version_arr = explode(' = ', $module_version_raw);
+      $module_full_version = trim($module_version_arr[1]);
+      $module_sem_version_arr = explode('-', $module_version_arr[1]);
+      $module_sem_version = trim($module_sem_version_arr[1]);
+      $module_core_compat = trim($module_sem_version_arr[0]);
+      $module_sem_version_parts = explode('.', $module_sem_version);
+      $module_version_major = $module_sem_version_parts[0];
+      $module_version_minor = $module_sem_version_parts[1];
+      $module_version_patch = $module_sem_version_parts[2];
+      // Get proposed Backdrop version info.
+      $project = $projects[0];
+      $xml = backdrop_pm_get_tags("https://updates.backdropcms.org/release-history/$project/1.x");
+      $download_link = $xml->releases->release->download_link;
+      $proposed_version = $xml->releases->release->version;
+      $proposed_version_major = $xml->releases->release->version_major;
+      $proposed_version_minor = $xml->releases->release->version_minor;
+      $proposed_version_patch = $xml->releases->release->version_patch;
+
+      if (empty($proposed_version)) {
+        drush_print_r("\tThere are no official releases for \033[1m$project\033[0m.
+        Upgrading is not possible.
+        ");
+      }
+      elseif ($module_full_version == $proposed_version) {
+        drush_print_r("\n\t\tProject \033[1m$project\033[0m is up to date :).\n");
+      }
+      elseif (
+        (
+          $module_version_major == $proposed_version_major &&
+          $module_version_minor == $proposed_version_minor &&
+          $module_version_patch < $proposed_version_patch
+        ) ||
+        (
+          $module_version_major == $proposed_version_major &&
+          $module_version_minor < $proposed_version_minor
+        )
+      ) {
+        drush_print_r("\n\t\tCurrent \033[1m$project\033[0m Version: $module_full_version");
+        drush_print_r("\t\tProposed \033[1m$project\033[0m Version: $proposed_version\n");
+        drush_print_r("\t\e[33mWARNING\033[0m:  Updating \033[1m$project\033[0m will discard any
+        modifications made to \033[1m$project\033[0m files.  If you have made any
+        modifications to these files, please back them up before updating so that
+        you can re-create your modifications in the updated version of the file.\n\n");
+        drush_print_r("\tNote: Updating modules can potentially break your site.
+        It is NOT recommended to update production sites without prior testing.\n\n");
+        $answer = drush_prompt("Do you wish to continue? (y or n)");
+        $answer = strtolower($answer);
+        if ($answer == 'y' || $answer == 'yes') {
+          drush_print_r("\t Backing up current \033[1m$project\033[0m folder to
+          ~/.drush/$project-$module_full_version");
+          exec("mv $module_path/$project ~/.drush/$project-$module_full_version");
+          exec("mkdir -p $backdrop_root/drush-tmp");
+          exec("wget --quiet -P $backdrop_root/drush-tmp $download_link");
+          exec("unzip $backdrop_root/drush-tmp/$project.zip -d $backdrop_root/drush-tmp");
+          exec("mv $backdrop_root/drush-tmp/$project $module_path/$project");
+          exec("rm -r $backdrop_root/drush-tmp");
+          exec("drush updb -y");
+          drush_print_r("\n\tYou can retrieve your old \033[1m$project\033[0m files, should you need
+          to, from: ~/.drush/$project-$module_version");
+          drush_print_r("\t\e[32mSuccess\033[0m: Project \033[1m$project\033[0m exitingupdated to $proposed_version.");
+        }
+        else {
+          drush_print_r("\tBackdrop core update cancelled.");
+        }
+      }
+    }
+    else {
+      drush_print_r("\n\t\e[33mWARNING\033[0m: There is no project \e[1m$projects[0]\033[0m intalled on your backdrop site.");
+      drush_print_r("\tNo action taken.\n");
+    }
+  } // end of drush up $project[0]
+  else {
+    drush_print_r("\n\tYou must specify a project to update. For example:\n");
+    drush_print_r("\t\tdrush up project_name");
+    drush_print_r("\n\tWhere project_name is the machine name of the project like webform or devel etc.\n");
   }
 }


### PR DESCRIPTION
This is setting the status of the module to 1, but is not calling install.module functions, so for example the config forms are not accessible in the Backdrop UI.
