### PR TITLE
Issue #52: Add support for pm-disable.

### DIFF
--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -62,6 +62,9 @@ function backdrop_drush_command_alter(&$command) {
     case 'pm-enable':
       $backdrop_command = 'backdrop-pm-enable';
       break;
+    case 'pm-disable':
+      $backdrop_command = 'backdrop-pm-disable';
+      break;
   }
 
   // Commands that work with Backdrop with no adjustments.

--- a/commands/pm/backdrop_pm_disable.drush.inc
+++ b/commands/pm/backdrop_pm_disable.drush.inc
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file
+ * Drush project management disable command.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function backdrop_pm_disable_drush_command() {
+  $items = array();
+  $items['backdrop-pm-disable'] = array(
+    'description' => 'Disable backdrop module(s).',
+    'callback' => 'backdrop_command_pm_disable',
+    'hidden' => TRUE,
+    'arguments' => array(
+      'module-name' => array('The name of the module(s) you would like to disable.'),
+    ),
+    'required-arguments' => TRUE,
+    'aliases' => array('dis', 'pm-disable'),
+    'bootstrap' => \Drush\Boot\BackdropBoot::BOOTSTRAP_FULL,
+  );
+
+  return $items;
+}
+
+/**
+ * pm-disable callback. Disable module or theme.
+ *
+ * @return bool
+ *
+ * @see _disable_project($project).
+ */
+function backdrop_command_pm_disable() {
+  $projects = func_get_args();
+  if (!isset($projects)) {
+    drush_print_r(dt("\n\n\t\e[31mError[0m Please provide at least one project name.\n"));
+    return FALSE;
+  }
+
+  $clear_cache = FALSE;
+  foreach($projects as $project ) {
+    if (_disable_project($project)) {
+      $clear_cache = TRUE;
+    }
+  }
+
+  if ($clear_cache) {
+    backdrop_flush_all_caches();
+  }
+}
+
+/**
+ * Internal function to disable module(s).
+ *
+ * @param string $project
+ *  Project machine name to be disabled.
+ *
+ * @return bool
+ */
+function _disable_project($project) {
+  $query = db_select('system', 's')
+    ->fields('s');
+  $query->condition('name', $project);
+  $query->condition('type', 'module');
+  $module = $query->execute()->fetchAssoc();
+  if (!$module) {
+    return FALSE;
+  }
+
+  if (!$module['status']) {
+    drush_print_r(
+      "\n\t\e[031mFailed\e[0m to disable $project module: it is already disabled.\n"
+    );
+    return FALSE;
+  }
+
+  if (!drush_confirm(dt("\n\tDo you want to disable $project?"))) {
+    drush_print_r(
+      dt("\n\t\e[33mCancelled\e[0m $project was not disabled.\n")
+    );
+    return FALSE;
+  }
+
+  module_disable(array($project), FALSE);
+  drush_print_r("\n\t\e[32mSuccess\e[0m module $project disabled.\n");
+  return TRUE;
+}


### PR DESCRIPTION
This works™ if you enable the module with drush, but if you enable in the backdrop UI and then subsequently try to disable with `drush dis {project}` it throws errors all thought the module is actually disabled.

`drush dis headless` example output:

```
geoff@gspmbp backdrop $ drush dis headless -y

        Do you want to disable headless? (y/n): y
PHP Fatal error:  Class 'Drupal\Core\Logger\RfcLogLevel' not found in /Users/geoff/drush/commands/core/drupal/environment.inc on line 334

Fatal error: Class 'Drupal\Core\Logger\RfcLogLevel' not found in /Users/geoff/drush/commands/core/drupal/environment.inc on line 334
Drush command terminated abnormally due to an unrecoverable error.                                                                                                     [error]
Error: Class 'Drupal\Core\Logger\RfcLogLevel' not found in /Users/geoff/drush/commands/core/drupal/environment.inc, line 334
```

We may have had problems with the `RfcLogLevel` before, but I can not exactly remember the context or what/if there was a resolution.

~Geoff
