### PR TITLE
Issue #65, Add support for `drush sa`

### DIFF
--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -91,6 +91,7 @@ function backdrop_drush_command_alter(&$command) {
     'topic',
     'php-eval',
     'php-script',
+    'site-alias',
     'sql-cli',
     'sql-conf',
     'sql-connect',


### PR DESCRIPTION
Note that the `*.aliases.drushrc.php` file could (should ?) be placed in a `drush` sub-folder of your webroot.