### PR TITLE
Issue #105: Allow modules to specify Backdrop drush commands.

### DIFF
--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -115,6 +115,11 @@ function backdrop_drush_command_alter(&$command) {
   if (in_array($command['command'], $safe_commands)) {
     return;
   }
+  // Commands provided by Backdrop modules relative to this site installation.
+  if (strpos($command['path'], '/') !== 0 && strpos($command['path'], 'modules') !== FALSE) {
+    return;
+  }
+
   // Commands that are fine to be run through the compatibility layer.
   if (in_array($command['command'], $compatible_commands)) {
     require_once BACKDROP_ROOT . '/core/includes/drupal.inc';


### PR DESCRIPTION
This attempts to solve https://github.com/backdrop-contrib/drush/issues/105.

Commands specified by global drush use an absolute path, so they start with "/" i.e. `/usr/local/bin/drush/core/commands/[file].inc`. But module-provided commands are local, such as `modules/devel.drush.inc`. As per-directory drush installations may also be used, I added a check for the string "modules" to decern between local drush installs and local Backdrop modules.