### PR TITLE
added civicrm-install to safe commands

### DIFF
--- a/backdrop.drush.inc
+++ b/backdrop.drush.inc
@@ -134,6 +134,7 @@ function backdrop_drush_command_alter(&$command) {
     'sql-query',
     'sql-sanitize',
     'release-notes',
+    'civicrm-install',
   );
 
   $compatible_commands = array(


### PR DESCRIPTION
I have been having an issue with Civicrm drush command and backdrop mainly because of the need to whitelist safe commands and/or have an enabled module with the drush commands in a modules dir.

This would normally be fine and civicrm does have a drush dir within it's module, the only issue is is that the drush commands are not available unless the module has been enabled first.  The civicrm-install process needs to run before the module is enabled, enabling it beforehand breaks the site.

I've looked at options to work around this and they're either hacky or sledgehammers.  The most elegant and straightforward way is to include civicrm-install command into the safe commands array in this project.  I've made a note of some of the options here https://github.com/polydigital/backdrop-civicrm-docker/issues/17

It wouldn't impact other use-cases with/without civicrm and the civicrm-install has been well tested (and fixed) now by me. here: https://github.com/civicrm/civicrm-backdrop/blob/1.x-master/drush/civicrm.drush.inc

I hope this can be merged in even though civicrm isn't anything to do with backdrop core of course - it would be useful for others too I'm sure.