### PR TITLE
Add description key name to prevent e-notice

### DIFF
--- a/commands/pm/backdrop_pm.drush.inc
+++ b/commands/pm/backdrop_pm.drush.inc
@@ -14,7 +14,7 @@ function backdrop_pm_drush_command() {
     'callback' => 'backdrop_command_pm_download',
     'hidden' => TRUE,
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to download.'),
+      'module-name' => array('description' => 'The name of the module(s) you would like to download.'),
     ),
     'options' => array(
       'select' => 'Select the version of the module.',
@@ -27,7 +27,9 @@ function backdrop_pm_drush_command() {
     'description' => 'Update Backdrop core or contrib modules.',
     'callback' => 'backdrop_command_pm_update',
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to update.'),
+      'module-name' => array(
+        'description' => 'The name of the module(s) you would like to update.',
+      ),
     ),
     // TODO: show available updates and allow for selection of which to apply.
     // 'options' => array(

--- a/commands/pm/backdrop_pm_disable.drush.inc
+++ b/commands/pm/backdrop_pm_disable.drush.inc
@@ -16,7 +16,9 @@ function backdrop_pm_disable_drush_command() {
     'description' => 'Disable backdrop modules.',
     'callback' => 'backdrop_command_pm_disable',
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to disable.'),
+      'module-name' => array(
+        'description' => 'The name of the module(s) you would like to disable.',
+      ),
     ),
     'aliases' => array('dis'),
     'required-arguments' => TRUE,

--- a/commands/pm/backdrop_pm_enable.drush.inc
+++ b/commands/pm/backdrop_pm_enable.drush.inc
@@ -16,7 +16,9 @@ function backdrop_pm_enable_drush_command() {
     'callback' => 'backdrop_command_pm_enable',
     'hidden' => TRUE,
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to enable.'),
+      'module-name' => array(
+        'description' =>  'The name of the module(s) you would like to enable.',
+      ),
     ),
     'required-arguments' => TRUE,
     'aliases' => array('en'),

--- a/commands/pm/backdrop_pm_uninstall.drush.inc
+++ b/commands/pm/backdrop_pm_uninstall.drush.inc
@@ -14,7 +14,7 @@ function backdrop_pm_uninstall_drush_command() {
     'description' => 'Uninstall backdrop modules.',
     'callback' => 'backdrop_command_pm_uninstall',
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to uninstall.'),
+      'module-name' => array('description' => 'The name of the module(s) you would like to uninstall.'),
     ),
     'aliases' => array('pmu'),
     'required-arguments' => TRUE,

--- a/commands/pm/download_backdrop.drush.inc
+++ b/commands/pm/download_backdrop.drush.inc
@@ -14,7 +14,7 @@ function download_backdrop_drush_command() {
     'callback' => 'backdrop_download_backdrop',
     'hidden' => TRUE,
     'arguments' => array(
-      'module-name' => array('The name of the module(s) you would like to download.'),
+      'module-name' => array('description' => 'The name of the module(s) you would like to download.'),
     ),
     'options' => array(
       'select' => 'Select the version of the module.',


### PR DESCRIPTION
I'm seeing enotices on drush 8.3.2 as it is looking for these to be keyed by 'description'

I believe this is fully backwards compatible to earlier drush versions