### PR TITLE
Fix Issue with system query in php8

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -126,7 +126,7 @@ function drush_module_dependents($modules, $module_info) {
  */
 function drush_module_list() {
   $enabled = array();
-  $rsc = drush_db_select('system', 'name', 'type=:type AND status=:status', array(':type' => 'module', ':status' => 1));
+  $rsc = drush_db_select('system', 'name', 'type = \'module\' AND status = 1', []);
   while ($row = drush_db_result($rsc)) {
     $enabled[$row] = $row;
   }
@@ -141,7 +141,7 @@ function drush_module_list() {
  */
 function drush_get_named_extensions_list($extensions) {
   $result = array();
-  $rsc = drush_db_select('system', array('name', 'status'), 'name IN (:extensions)', array(':extensions' => $extensions));
+  $rsc = drush_db_select('system', array('name', 'status'), 'name IN (\'' . implode("', '", $extensions) .  '\')', []);
   while ($row = drush_db_fetch_object($rsc)) {
     $result[$row->name] = $row;
   }


### PR DESCRIPTION
We (CiviCRM) have been testing out php8 on our CI infrastructure and using a development version of drush8 and have found that we get the following error when trying to do a drush user-create command 

```
PDOException: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens: SELECT name FROM {system} WHERE type=&#039;module&#039; AND status=1; Array
(
    [:type] => module
    [:status] => 1
)
 in drush_db_select() (line 131 of phar:///home/jenkins/bknix-edge/bin/drush8/includes/dbtng.inc).
```

This resolves it by avoiding the use of parameters as they get replaced https://github.com/drush-ops/drush/blob/8.x/includes/dbtng.inc#L111 but then still passed to db_query https://github.com/drush-ops/drush/blob/8.x/includes/dbtng.inc#L131 and it seemed easier to patch the backdrop integration than drush

ping @herbdool @totten