### PR TITLE
Issue #254: Resolve additional PHP8+ errors.

### DIFF
--- a/BackdropBoot.php
+++ b/BackdropBoot.php
@@ -615,7 +615,7 @@ class BackdropBoot extends BaseBoot {
   // @codingStandardsIgnoreLine
   protected function module_list() {
     $enabled = array();
-    $rsc = drush_db_select('system', 'name', 'type=:type AND status=:status', array(':type' => 'module', ':status' => 1));
+    $rsc = drush_db_select('system', 'name', "type='module' AND status=1", array());
     while ($row = drush_db_result($rsc)) {
       $enabled[$row] = $row;
     }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -126,7 +126,7 @@ function drush_module_dependents($modules, $module_info) {
  */
 function drush_module_list() {
   $enabled = array();
-  $rsc = drush_db_select('system', 'name', 'type = \'module\' AND status = 1', []);
+  $rsc = drush_db_select('system', 'name', 'type = \'module\' AND status = 1', array());
   while ($row = drush_db_result($rsc)) {
     $enabled[$row] = $row;
   }
@@ -141,7 +141,7 @@ function drush_module_list() {
  */
 function drush_get_named_extensions_list($extensions) {
   $result = array();
-  $rsc = drush_db_select('system', array('name', 'status'), 'name IN (\'' . implode("', '", $extensions) .  '\')', []);
+  $rsc = drush_db_select('system', array('name', 'status'), 'name IN (\'' . implode("', '", $extensions) .  '\')', array());
   while ($row = drush_db_fetch_object($rsc)) {
     $result[$row->name] = $row;
   }


### PR DESCRIPTION
Helps with https://github.com/backdrop-contrib/backdrop-drush-extension/issues/254.

After merging https://github.com/backdrop-contrib/backdrop-drush-extension/pull/251 I found there's still another query in `BackdropBoot.php` that needs to avoid using query parameters.