### PR TITLE
Issue #238: Change DRUSH_BOOTSTRAP_DRUSH to DRUSH_BOOTSTRAP_NONE.

### DIFF
--- a/BackdropBoot.php
+++ b/BackdropBoot.php
@@ -121,7 +121,7 @@ class BackdropBoot extends BaseBoot {
    *
    * Phases:
    *
-   *     DRUSH_BOOTSTRAP_DRUSH   = Only Backdrop.
+   *     DRUSH_BOOTSTRAP_NONE    = Only Drush.
    *     BOOTSTRAP_ROOT          = Find a valid Drupal root.
    *     BOOTSTRAP_SITE          = Find a valid Drupal site.
    *     BOOTSTRAP_CONFIGURATION = Load the site's settings.

--- a/grn/grn.drush.inc
+++ b/grn/grn.drush.inc
@@ -80,7 +80,7 @@ function grn_drush_command() {
     // I keep typing it, but not intuitive for others.
     'deprecated-aliases' => array('grn'),
     // No bootstrap needed.
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'bootstrap' => DRUSH_BOOTSTRAP_NONE,
   );
   return $items;
 }


### PR DESCRIPTION
Replaces https://github.com/backdrop-contrib/backdrop-drush-extension/pull/239

Fixes #238.